### PR TITLE
Fix the namespace reference on the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ require_once "vendor/autoload.php";
 Create a client with your API key and secret:
 
 ```php
-$client = new Nexmo\Client(new Nexmo\Credentials\Basic(API_KEY, API_SECRET));     
+$client = new Nexmo\Client(new Nexmo\Client\Credentials\Basic(API_KEY, API_SECRET));     
 ```
 
 Examples


### PR DESCRIPTION
The namespace for `Nexmo\Client\Credentials\Basic` was `Nexmo\Credentials\Basic`

Just added a small fix to avoid misunderstanding.
